### PR TITLE
add -std=c99 to cflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -g
+CFLAGS = -g -std=c99
 PATH_BUILD = ./build
 PATH_PARSON = library/parson
 OBJS = $(PATH_BUILD)/*.o


### PR DESCRIPTION
note: use option -std=c99 or -std=gnu99 to compile your code
gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)